### PR TITLE
Fix: Correct undefined variable in ReadingStats component

### DIFF
--- a/client/src/pages/ReadingStats.js
+++ b/client/src/pages/ReadingStats.js
@@ -121,12 +121,12 @@ export default function ReadingStats() {
       <div className="book-highlights"> {/* These should use .insight-card or similar from App.css */}
         <BookHighlight
           title="Longest Book"
-          book={pageStats.longestBook}
+          book={pageStatsData.longestBook}
           className="highlight-purple"
         />
         <BookHighlight
           title="Shortest Book"
-          book={pageStats.shortestBook}
+          book={pageStatsData.shortestBook}
           className="highlight-pink"
         />
       </div>


### PR DESCRIPTION
Corrects eslint `no-undef` errors in `client/src/pages/ReadingStats.js` by changing `pageStats.longestBook` and `pageStats.shortestBook` to `pageStatsData.longestBook` and `pageStatsData.shortestBook` respectively.

The issue title mentioned a "react-icons missing module" problem. However, `react-icons` is present in `client/package.json` (version ^4.10.1) and was not found to be the cause of the build failure. The build failure was due to the `eslint` errors mentioned above. No direct usage of `react-icons` was found in `ReadingStats.js`.