### PR TITLE
fix: Remove import for deleted Goals page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,7 +15,6 @@ import Dashboard from './pages/Dashboard';
 import YearlyProgress from './pages/YearlyProgress';
 import MonthlyProgress from './pages/MonthlyProgress';
 import RecentBooks from './pages/RecentBooks';
-import Goals from './pages/Goals';
 import TopAuthors from './pages/TopAuthors';
 import ReadingStats from './pages/ReadingStats';
 import DataManagement from './pages/DataManagement';


### PR DESCRIPTION
Removes the `import Goals from './pages/Goals';` statement from `client/src/App.js` to resolve a build failure caused by the Goals component's deletion in a previous commit.