### PR TITLE
Fix: Key Statistics Boxes dark mode theming

### DIFF
--- a/client/src/pages/Dashboard.css
+++ b/client/src/pages/Dashboard.css
@@ -79,7 +79,7 @@
   .stat-value { /* This is already in App.css, ensure consistency or override */
     font-size: 2rem; /* Kept from previous densification */
     font-weight: 700;
-    color: var(--night-owl-accent2); 
+  color: var(--current-text);
     margin-bottom: 0.1rem; 
   }
   


### PR DESCRIPTION
Updated the text color of the Key Statistics Boxes to use a CSS variable (`--current-text`) ensuring they correctly adapt to both light and dark themes.

This resolves an issue where the statistics values were hardcoded to a light-theme-specific color, causing poor visibility in dark mode.