### PR TITLE
Fix: Correct CSS variables for dark mode in Dashboard

### DIFF
--- a/client/src/pages/Dashboard.css
+++ b/client/src/pages/Dashboard.css
@@ -3,7 +3,7 @@
 
 .dashboard {
     padding: 1rem; 
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
   }
   
   .dashboard h1 { /* Uses var(--h1-font-size) from index.css by default */
@@ -29,13 +29,14 @@
   .recent-books,
   .reading-insights,
   .authors-list-card { 
-    background-color: var(--current-card-background); /* Themed */
+    background-color: hsl(var(--card)); /* CORRECT */
+    border: 1px solid hsl(var(--border)); /* CORRECT */
+    color: hsl(var(--card-foreground)); /* CORRECT */
     border-radius: var(--border-radius, 8px); 
     box-shadow: 0 2px 5px rgba(0,0,0,0.3); 
     padding: 1rem; 
     margin-bottom: 1rem; 
-    border: 1px solid var(--current-border); /* Themed */
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.3s ease, border-color 0.3s ease; /* Added theme transitions */
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.3s ease, border-color 0.3s ease;
   }
   
   .stat-card:hover, 
@@ -49,12 +50,12 @@
   
   /* Section for grouping related stats - can be a new div in JSX */
   .stats-group-container {
-    background-color: var(--current-card-background); /* Themed */
+    background-color: hsl(var(--card)); /* Themed */
     border-radius: var(--border-radius, 8px);
     box-shadow: 0 2px 5px rgba(0,0,0,0.3);
     padding: 1rem;
     margin-bottom: 1rem;
-    border: 1px solid var(--current-border); /* Themed */
+    border: 1px solid hsl(var(--border)); /* Themed */
     transition: background-color 0.3s ease, border-color 0.3s ease; /* Added theme transitions */
   }
   
@@ -71,7 +72,7 @@
   .stat-card h3 { /* Uses var(--h3-font-size) from index.css or component-specific */
     margin-top: 0;
     margin-bottom: 0.25rem; 
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
     font-size: 0.9rem; /* Kept from previous densification, smaller than base h3 */
     font-weight: 500;
   }
@@ -79,7 +80,7 @@
   .stat-value { /* This is already in App.css, ensure consistency or override */
     font-size: 2rem; /* Kept from previous densification */
     font-weight: 700;
-  color: var(--current-text);
+  color: hsl(var(--card-foreground));
     margin-bottom: 0.1rem; 
   }
   
@@ -115,13 +116,13 @@
   .goal-card h3 { /* Uses var(--h3-font-size) from index.css or component-specific */
     margin-top: 0;
     margin-bottom: 0.25rem;
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
     font-size: 1rem; /* Kept from previous densification */
   }
   
   .progress-bar { /* This is in App.css, check if override is needed */
     height: 10px; 
-    background-color: var(--current-border); /* Themed */
+    background-color: hsl(var(--border)); /* Themed */
     border-radius: 5px;
     overflow: hidden;
     margin-bottom: 0.25rem;
@@ -135,7 +136,7 @@
   
   .progress-text { /* This is in App.css */
     font-size: 0.8rem; 
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
   }
   
   .set-goals-link, .see-more-link { /* These are <a> tags, will inherit from App.css <a> styles */
@@ -164,7 +165,7 @@
   .chart-card h3 { /* Uses var(--h3-font-size) from index.css or component-specific */
     margin-top: 0;
     margin-bottom: 1rem; 
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
     font-size: 1.1rem; /* Kept from previous densification */
     font-weight: 600;
     text-align: center;
@@ -174,11 +175,11 @@
   /* Ensure font-family is inherited or explicitly set if Recharts overrides it */
   .recharts-text, .recharts-legend-item-text, .recharts-tooltip-label, .recharts-tooltip-item {
     font-family: var(--font-base) !important; /* Explicitly set Fira Code */
-    fill: var(--current-text) !important; /* Themed */
+    fill: hsl(var(--card-foreground)) !important; /* Themed */
     font-size: 0.8rem; /* Slightly smaller for chart elements */
   }
   .recharts-cartesian-axis-line, .recharts-cartesian-grid-line {
-    stroke: var(--current-border) !important; /* Themed */
+    stroke: hsl(var(--border)) !important; /* Themed */
   }
   
   .top-authors {
@@ -194,7 +195,7 @@
   .author-name {
     display: block;
     font-weight: 600;
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
     margin-bottom: 0.1rem;
     font-size: 0.9rem; /* Kept from previous densification */
   }
@@ -202,13 +203,13 @@
   .author-count {
     display: block;
     font-size: 0.8rem; /* Kept */
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
     margin-bottom: 0.1rem;
   }
   
   .author-bar { /* This is in App.css, check if override is needed */
     height: 6px; 
-    background-color: var(--current-border); /* Themed */
+    background-color: hsl(var(--border)); /* Themed */
     border-radius: 3px;
     overflow: hidden;
   }
@@ -242,7 +243,7 @@
   .book-title { /* Uses var(--h3-font-size) from index.css or component-specific */
     margin-top: 0;
     margin-bottom: 0.25rem;
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
     font-size: 0.95rem; /* Slightly adjusted for Fira Code */
     font-weight: 600;
     line-height: 1.25; /* Adjusted for Fira Code */
@@ -255,7 +256,7 @@
   .book-author {
     margin-top: 0;
     margin-bottom: 0.25rem;
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
     font-size: 0.75rem; /* Adjusted for Fira Code */
     font-style: italic; /* Keep italic if desired, Fira Code supports it */
   }
@@ -268,7 +269,7 @@
   
   .book-date, .book-pages {
     margin: 0;
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
     font-size: 0.7rem; /* Adjusted for Fira Code */
   }
   
@@ -305,14 +306,14 @@
   .insight-card h3 { /* Uses var(--h3-font-size) from index.css or component-specific */
     margin-top: 0;
     margin-bottom: 0.25rem;
-    color: var(--current-text); /* Themed */
+    color: hsl(var(--card-foreground)); /* Themed */
     font-size: 0.95rem; /* Adjusted for Fira Code */
     font-weight: 600;
   }
   
   .insight-card p {
     margin: 0;
-    color: var(--current-text);  /* Themed */
+    color: hsl(var(--card-foreground));  /* Themed */
     font-size: 0.8rem; /* Adjusted for Fira Code */
   }
   


### PR DESCRIPTION
Replaced incorrect CSS variable names in client/src/pages/Dashboard.css to ensure components respect dark mode theming.

- Replaced `var(--current-card-background)` with `hsl(var(--card))`
- Replaced `var(--current-text)` with `hsl(var(--card-foreground))`
- Replaced `var(--current-border)` with `hsl(var(--border))`
- Added `color: hsl(var(--card-foreground));` to the main card styling block for consistent text color.

This resolves the issue where key statistics boxes and other card elements in the dashboard were not displaying correctly in dark mode due to referencing non-existent CSS variables.