### PR TITLE
Fix: Correct statistical calculations for reading pace

### DIFF
--- a/client/src/context/ReadingDataContext.js
+++ b/client/src/context/ReadingDataContext.js
@@ -223,6 +223,27 @@ export const ReadingDataProvider = ({ children }) => {
 
     const numBooksWithValidDates = booksWithValidDates.length;
 
+    // New logic for Books/Month
+    const currentYear = new Date().getFullYear();
+    const booksThisYear = booksWithValidDates.filter(book => {
+      const year = new Date(book.dateRead).getFullYear();
+      return year === currentYear;
+    });
+    const monthsElapsedThisYear = new Date().getMonth() + 1; // January is 0, so add 1
+    const booksPerMonthCurrentYear = monthsElapsedThisYear > 0 ? booksThisYear.length / monthsElapsedThisYear : 0;
+
+    // New logic for Pages/Day
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const recentBooks = booksWithValidDates.filter(book => {
+      const readDate = new Date(book.dateRead);
+      return readDate >= thirtyDaysAgo;
+    });
+
+    const recentPages = recentBooks.reduce((sum, book) => sum + (book.pages || 0), 0);
+    const pagesPerDayLast30Days = recentBooks.length > 0 ? recentPages / 30 : 0;
+
     return {
       totalBooks: books.length, // Original total books
       averageRating: numBooksWithValidDates > 0
@@ -240,9 +261,9 @@ export const ReadingDataProvider = ({ children }) => {
           }, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 })
         : { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }, // Default if no books with valid dates
       readingPace: {
-        booksPerMonth: numBooksWithValidDates / totalReadingMonths,
+        booksPerMonth: booksPerMonthCurrentYear, // Updated calculation
         booksPerYear: numBooksWithValidDates, // As per instruction, keep this based on count
-        pagesPerDay: totalPagesWithValidDates / totalReadingDays,
+        pagesPerDay: pagesPerDayLast30Days, // Updated calculation
       },
       pageStats: {
         totalPages: totalPagesWithValidDates,

--- a/client/src/pages/ReadingStats.js
+++ b/client/src/pages/ReadingStats.js
@@ -61,8 +61,8 @@ export default function ReadingStats() {
 
       <div className="stats-overview"> {/* These should use the .stat-card styles from App.css now */}
         <Card title="Avg Books / Year" value={pace.booksPerYear.toFixed(1)} />
-        <Card title="Avg Books / Month" value={pace.booksPerMonth.toFixed(1)} />
-        <Card title="Avg Pages / Day" value={pace.pagesPerDay.toFixed(1)} />
+        <Card title="Current Year Pace (Books/Month)" value={pace.booksPerMonth.toFixed(1)} />
+        <Card title="Recent Pace (Pages/Day)" value={pace.pagesPerDay.toFixed(1)} />
         <Card title="Avg Book Length" value={pageStatsData.averageLength.toFixed(0) + 'p'} />
       </div>
 


### PR DESCRIPTION
This commit addresses an issue where 'Books/Month' and 'Pages/Day' metrics were calculated using your entire reading history, leading to misleading statistics.

The following changes have been made:

1.  **Books/Month Calculation Updated**:
    - The 'Books/Month' metric in `client/src/context/ReadingDataContext.js` now calculates the reading pace based on books you've read in the current year divided by the number of months elapsed in the current year.
    - Handles cases where you haven't read any books this year or no months have elapsed.

2.  **Pages/Day Calculation Updated**:
    - The 'Pages/Day' metric in `client/src/context/ReadingDataContext.js` now calculates the reading pace based on the total pages you've read in the last 30 days, divided by 30.
    - Handles cases where you haven't read any books in the last 30 days.

3.  **UI Labels Updated**:
    - In `client/src/pages/ReadingStats.js`, the display labels for these metrics have been updated to reflect their new meaning: - "Avg Books / Month" is now "Current Year Pace (Books/Month)" - "Avg Pages / Day" is now "Recent Pace (Pages/Day)"

These changes ensure that the reading habit tracker provides more accurate and relevant insights into your current reading pace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reading pace statistics now reflect books read per month in the current year and pages read per day over the last 30 days.

- **Style**
  - Updated labels for reading pace cards to "Current Year Pace (Books/Month)" and "Recent Pace (Pages/Day)" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->