### PR TITLE
Fix: Ensure stats are always recalculated and not loaded from stale c…

### DIFF
--- a/client/src/components/DataManagement.css
+++ b/client/src/components/DataManagement.css
@@ -81,6 +81,15 @@
   background-color: #d32f2f;
 }
 
+.action-button.warning-button {
+  background-color: #f0ad4e; /* Orange for warning */
+  color: white;
+}
+
+.action-button.warning-button:hover {
+  background-color: #ec971f;
+}
+
 .file-input-label {
   display: inline-block;
   padding: 0.75rem 1rem;

--- a/client/src/components/DataManagement.js
+++ b/client/src/components/DataManagement.js
@@ -4,7 +4,7 @@ import { useReadingData } from '../context/ReadingDataContext';
 import './DataManagement.css';
 
 const DataManagement = () => {
-  const { readingData, stats, goalProgress, processReadingData, clearAllData } = useReadingData();
+  const { readingData, stats, goalProgress, processReadingData, clearAllData, forceClearAndRecalculate } = useReadingData();
   const [importError, setImportError] = useState(null);
   const [exportSuccess, setExportSuccess] = useState(false);
   const [importSuccess, setImportSuccess] = useState(false);
@@ -147,6 +147,21 @@ const DataManagement = () => {
             onClick={handleClearData}
           >
             Clear Data
+          </button>
+
+          {/* New Button Below */}
+          <h3>Force Cache Clear & Recalculate</h3>
+          <p>This is a temporary tool to clear cached stats from local storage and force recalculation. Use if stats seem incorrect.</p>
+          <button
+            className="action-button warning-button" // You might need to add styling for 'warning-button'
+            onClick={() => {
+              if (window.confirm('Are you sure you want to clear cached stats and force recalculation? This may be helpful for troubleshooting display issues.')) {
+                forceClearAndRecalculate();
+                alert('Cache cleared and stats recalculated. Refresh the dashboard to see changes.');
+              }
+            }}
+          >
+            Force Recalculate Stats
           </button>
         </div>
       </div>


### PR DESCRIPTION
…ache

This commit addresses a critical bug where old, incorrect statistics were being loaded from localStorage and used in the dashboard, even after the underlying calculation logic was fixed.

The following changes were implemented:
1.  Modified the main `useEffect` in `ReadingDataContext.js` to always recalculate stats (`stats` and `goalProgress`) from the books data upon initial application load. It no longer loads these from localStorage directly.
2.  Updated the `processReadingData` function in `ReadingDataContext.js` to always recalculate stats when new data is processed, ignoring any stats that might be part of the input data object.
3.  Added a `forceClearAndRecalculate` function to `ReadingDataContext.js` and a corresponding button in the "Data Management" page. This temporary utility allows you to manually clear any cached stats from localStorage and trigger a recalculation using the current books data in the state.

These changes ensure that the dashboard always displays freshly calculated statistics, resolving the issue of stale cached data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Force Recalculate Stats" button in Data Management, allowing users to clear cached statistics and force recalculation of stats and goal progress.
  - Introduced a new warning-themed button style for enhanced visual distinction.

- **Bug Fixes**
  - Statistics and goal progress are now always recalculated from current data, ensuring accuracy when loading or processing reading data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->