### PR TITLE
feat: Add favicons and configure Vite

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -9,6 +9,12 @@
       content="Reading Habit Tracker - Track your reading habits over time"
     />
     <title>Reading Habit Tracker</title>
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="icon" href="/favicon-16x16.png" type="image/png" sizes="16x16">
+    <link rel="icon" href="/favicon-32x32.png" type="image/png" sizes="32x32">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="android-chrome-192x192" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+    <link rel="android-chrome-512x512" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+
+export default defineConfig({
+  publicDir: 'public',
+  // If there are other configurations, they should be preserved.
+  // For now, we are only adding publicDir.
+  // Example of how other configurations might look:
+  // resolve: {
+  //   alias: {
+  //     '@': resolve(__dirname, 'src'),
+  //   },
+  // },
+})


### PR DESCRIPTION
This commit introduces favicons to the reading habit tracker website.

The following changes were made:
- Created `client/vite.config.ts` and configured `publicDir` to `public` to ensure Vite serves favicon files correctly.
- Added various favicon meta tags to `client/public/index.html` to support different devices and browsers. This includes:
    - Standard `favicon.ico`
    - `favicon-16x16.png` and `favicon-32x32.png`
    - `apple-touch-icon.png`
    - `android-chrome-192x192.png` and `android-chrome-512x512.png`

These changes will enhance the professional appearance of the site by displaying a custom favicon across all browsers and devices.