### PR TITLE
feat: Add website logo to header

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -69,7 +69,7 @@ const Header = () => { // Removed toggleSidebar prop
     <header className="app-header">
       <div className="header-content">
         <Link to="/" className="logo">
-          <img src="/generated-icon.png" alt="Reading Habit Tracker" className="header-logo" />
+          <img src="/reading-habit-tracker-logo.png" alt="Reading Habit Tracker Logo" className="header-logo" />
           <h1>Reading Tracker</h1> {/* Simplified title */}
         </Link>
         


### PR DESCRIPTION
- Updated the header component to display the website logo (`reading-habit-tracker-logo.png`) instead of the generated icon.
- Updated the alt text for the logo to "Reading Habit Tracker Logo".
- Leveraged existing CSS class `.header-logo` for styling, which includes responsive height adjustments.