### PR TITLE
Make paths configurable via env

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,9 +1,15 @@
+const path = require('path');
+
+// Allow the working directory to be overridden via environment variable.
+// Default to the directory containing this config file.
+const workingDir = process.env.PM2_CWD || path.resolve(__dirname);
+
 module.exports = {
   apps: [{
     name: "mybooks",  // ← Match existing PM2 name
     script: "npm",
     args: "start",
-    cwd: "/home/zk/projects/reading-habit-tracker",
+    cwd: workingDir,
     env: {
       NODE_ENV: "production"
     },

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -2,7 +2,11 @@ const winston = require('winston');
 const path = require('path');
 const fs = require('fs');
 
-const centralizedLogFile = '/home/zk/logs/mybooks.log';
+// Allow overriding the log directory via environment variable.
+// Defaults to a local "logs" folder within the project root for safety.
+const logDir = process.env.LOG_DIR ||
+  path.resolve(__dirname, '../../logs');
+const centralizedLogFile = path.join(logDir, 'mybooks.log');
 const centralizedLogDir = path.dirname(centralizedLogFile);
 
 // Create the directory if it doesn't exist.


### PR DESCRIPTION
## Summary
- allow setting log dir in `src/logger`
- allow setting working dir for pm2 in `ecosystem.config.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce96ed74c83229782858fd13d1597