### PR TITLE
Remove apt install from favicon script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ A web application for tracking and visualizing your reading habits using Goodrea
 
 - Node.js (v14 or higher)
 - npm or yarn
+- ImageMagick (provides the `convert` command used by `generate_favicons.sh`)
+
+To generate application favicons place your source image in `client/public` and run `./generate_favicons.sh`.
 
 ### 🚀 Installation
 

--- a/generate_favicons.sh
+++ b/generate_favicons.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-# Install ImageMagick if not already present
-if ! command -v convert &> /dev/null
-then
-    echo "ImageMagick not found. Installing..."
-    apt-get update && apt-get install -y imagemagick
-    echo "ImageMagick installed."
-else
-    echo "ImageMagick is already installed."
+# Verify ImageMagick is available
+if ! command -v convert >/dev/null 2>&1; then
+    echo "Error: ImageMagick 'convert' command not found. Please install ImageMagick before running this script." >&2
+    exit 1
 fi
 
 # Navigate to the public directory
@@ -16,7 +12,13 @@ mkdir -p client/public
 cd client/public
 
 # Define the source image
-SOURCE_IMAGE="generated-icon.png"
+SOURCE_IMAGE="${1:-generated-icon.png}"
+
+# Basic validation to avoid command injection
+if [[ "$SOURCE_IMAGE" =~ [^a-zA-Z0-9._/-] ]]; then
+    echo "Error: invalid characters in source image path." >&2
+    exit 1
+fi
 
 # Check if the source image exists
 if [ ! -f "$SOURCE_IMAGE" ]; then


### PR DESCRIPTION
## Summary
- avoid automatic installation of ImageMagick
- validate source image path
- mention ImageMagick requirement in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce96f2f848322bf258774af9def5b