### PR TITLE
fix: prevent infinite console logs on reading dashboard

### DIFF
--- a/client/src/context/ReadingDataContext.js
+++ b/client/src/context/ReadingDataContext.js
@@ -50,17 +50,11 @@ export const ReadingDataProvider = ({ children }) => {
     }
 
     const booksWithValidDates = books.filter(book => book.dateRead && !isNaN(new Date(book.dateRead)));
-    // eslint-disable-next-line no-console
-    console.debug("Total books (original input):", books.length);
-    // eslint-disable-next-line no-console
-    console.debug("Total books (with valid dates):", booksWithValidDates.length);
 
     const booksIn2025 = booksWithValidDates.filter(book => {
       const year = new Date(book.dateRead).getFullYear();
       return year === 2025;
     });
-    // eslint-disable-next-line no-console
-    console.debug("Books read in 2025 (with valid dates):", booksIn2025.length);
 
     // If no books have valid dates, return existing stats or a default for readingPace
     if (booksWithValidDates.length === 0) {
@@ -263,11 +257,6 @@ useEffect(() => {
 }, [calculateStats, calculateGoalProgress]); // Add dependencies if they are defined outside the effect
 
   const processReadingData = (data) => {
-    // eslint-disable-next-line no-console
-    console.debug("processReadingData called with:", data);
-    // console.log("Current readingData state:", readingData); // readingData might be stale here, prefer 'data'
-    // eslint-disable-next-line no-console
-    console.debug("Data type:", typeof data, "Array?", Array.isArray(data));
     setLoading(true);
     try {
       // ✅ ALWAYS recalculate stats, never trust pre-calculated ones

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -143,7 +143,7 @@ const Dashboard = () => {
   const ratingData = Object.entries(stats.ratingDistribution)
     .map(([rating, count]) => ({ rating: parseInt(rating), count }))
     .filter(item => item.count > 0 && item.rating > 0);
-  
+
   // Updated RATING_COLORS for Night Owl theme
   const RATING_COLORS = [
     '#ff5370', // 1 star (a bit more vibrant red)
@@ -155,7 +155,17 @@ const Dashboard = () => {
 
   const safeData = Array.isArray(readingData) ? readingData : [];
   // Display more recent books for a denser layout, e.g., 10
-  const recentBooks = safeData.slice(0, 10); 
+  const recentBooks = safeData.slice(0, 10);
+
+  const readThisYear = stats.readingByYear[currentYear] || 0;
+
+  // Log key stats only when values change to avoid console spam
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Total books:', stats.totalBooks);
+      console.log(`Read in ${currentYear}:`, readThisYear);
+    }
+  }, [stats.totalBooks, readThisYear, currentYear]);
   
   const tickFormatter = (value) => {
     if (typeof value === 'number' && value > 1000) {


### PR DESCRIPTION
## Summary
- remove debug console calls from ReadingDataContext
- log key statistics in Dashboard via a dedicated `useEffect`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d182a4cf883229023034d24502430