### PR TITLE
Fix conditional logging hook

### DIFF
--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -35,19 +35,24 @@ const lightThemeStyles = {
 const Dashboard = () => {
   const { stats, readingData, loading, error, goalProgress } = useReadingData();
 
- const readThisYear = stats.readingByYear[currentYear] || 0;
+  // Determine current year as soon as the component renders so it's available
+  // for other calculations
+  const currentYear = new Date().getFullYear().toString();
+  const previousYear = (parseInt(currentYear) - 1).toString();
 
-// Log key stats only when values change to avoid console spam
-React.useEffect(() => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    typeof stats.totalBooks === 'number' &&
-    typeof readThisYear === 'number'
-  ) {
-    console.log('Total books:', stats.totalBooks);
-    console.log(`Read in ${currentYear}:`, readThisYear);
-  }
-}, [stats.totalBooks, readThisYear, currentYear]);
+  const readThisYear = stats.readingByYear[currentYear] || 0;
+
+  // Log key stats only when values change to avoid console spam
+  React.useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      typeof stats.totalBooks === 'number' &&
+      typeof readThisYear === 'number'
+    ) {
+      console.log('Total books:', stats.totalBooks);
+      console.log(`Read in ${currentYear}:`, readThisYear);
+    }
+  }, [stats.totalBooks, readThisYear, currentYear]);
   
 
   // Function to determine active theme styles
@@ -141,8 +146,6 @@ React.useEffect(() => {
   stats.ratingDistribution = stats.ratingDistribution || {};
   
   // Prepare data for charts
-  const currentYear = new Date().getFullYear().toString();
-  const previousYear = (parseInt(currentYear) - 1).toString();
   
   const yearlyData = Object.entries(stats.readingByYear)
     .map(([year, count]) => ({ year, count }))


### PR DESCRIPTION
## Summary
- ensure stats logging effect is called unconditionally
- define `currentYear` and `previousYear` before using them

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2563baac8322aa42de89e8e8acb3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the organization of year-related calculations within the Dashboard, making the component logic clearer and reducing redundant computations. No visible changes to the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->